### PR TITLE
changed discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Popular meta data:
 
 On June 9, 2023, Croatia joined our projects. If you want to use Croatian language datasets just add lang parameter when creating Speakleash object.
 
-```
+```python
 from speakleash import Speakleash
 import os
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <a href="https://speakleash.org/dashboard/">
         <img src="https://img.shields.io/badge/dynamic/json?url=https://cutt.ly/lwlzZ4RZ&query=datasetsGB&suffix=%20GB&label=datasets&color=brightgreen">
     </a>
-    <a href="https://discord.com/invite/35cSny6Q?utm_source=Discord%20Widget&utm_medium=Connect">
+    <a href="https://speakleash.org/spolecznosc-i-kontakt/">
         <img src="https://img.shields.io/discord/1043112910278381619?logo=discord&label=discord&color=%23603FEF">
     </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and tools to make them useful.
 ## Installation
 
 Speakleash package can be installed from PyPi and has to be installed in a virtual environment:
-```
+```python
 pip install speakleash
 ```
 
@@ -40,7 +40,7 @@ pip install speakleash
 
 If you just want to see the details of the datasets
 
-```
+```python
 from speakleash import Speakleash
 import os
 
@@ -57,13 +57,13 @@ for d in sl.datasets:
 ```
 
 You can use individual properties (e.g.:***characters***, ***documents***), but you can display the entire manifest
-```
+```python
 sl = Speakleash(replicate_to)
 print(sl.get("plwiki").manifest)
 ```
 
 If you chose one of them (***.get(name of dataset)***) then you will get a lot of text data ;-)
-```
+```python
 from speakleash import Speakleash
 import os
 
@@ -78,7 +78,7 @@ for doc in wiki:
 ```
 
 If you also need meta data then use the ***ext_data*** property
-```
+```python
 ds = sl.get("plwiki").ext_data
 for doc in ds:
     print(doc)


### PR DESCRIPTION
Current discord hyperlink leads to the 'temporary' discord invitation, which will expire shortly. Temporary solution changes redirection (action) to the speakleash 'contact' site with a discord widget including 'join' option.