### PR TITLE
refactor: modification of main enitity imports

### DIFF
--- a/speakleash/__init__.py
+++ b/speakleash/__init__.py
@@ -11,5 +11,3 @@ Modules:
 """
 from .core import Speakleash
 from .category_manager import CategoryManager
-from .dataset import SpeakleashDataset
-from .downloader import StructureDownloader

--- a/speakleash/__init__.py
+++ b/speakleash/__init__.py
@@ -10,3 +10,6 @@ Modules:
 - structure_downloader: Provides the StructureDownloader class for downloading dataset structures in Speakleash.
 """
 from .core import Speakleash
+from .category_manager import CategoryManager
+from .dataset import SpeakleashDataset
+from .downloader import StructureDownloader


### PR DESCRIPTION
Modified import for the  `CategoryManager` class to be imported straight from the package as being one of the main classes to work with, alongside `Speakleash` class.

Changers were made in a `speakleash/__init__.py` file:
```
speakleash/
├── __init__.py
```